### PR TITLE
Update core.py

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -281,6 +281,8 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
             r = SystemRandom()
             if hashtype in ['md5']:
                 saltsize = 8
+            elif hashtype in ['blowfish']:
+                saltsize = 22
             else:
                 saltsize = 16
             saltcharset = string.ascii_letters + string.digits + '/.'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In the specific scenario:
- using password_hash("blowfish"), without a provided salt bcrypt dies because the salt size provided is 16, when bcrypt requires a 22 character salt. 
This can be done either by not passing a salt to crypt.crypt in the instance of bcrypt, or by generating a 22 character salt for bcrypt. This implementation followed the pattern of md5 of providing a salt length override for a specific hash ciphertype.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
jinja2 filter password_hash
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
